### PR TITLE
bugfix pyMCDS_timeseries.py and bugfix and extend test_single.py and test_timeseries.py

### DIFF
--- a/pyMCDS_timeseries.py
+++ b/pyMCDS_timeseries.py
@@ -83,7 +83,7 @@ class pyMCDS_timeseries:
         unique_types = np.unique(self.timeseries[0].data['discrete_cells']['cell_type'])
         cell_counts = np.zeros((times.shape[0], unique_types.shape[0]))
         for time_i in range(times.shape[0]):
-            df = self.timeseries[time_i].get_cells_df()
+            df = self.timeseries[time_i].get_cell_df()
             counts = df['cell_type'].value_counts()
             cell_counts[time_i, :] = counts
         fig, ax = plt.subplots(figsize=(10, 8))

--- a/test_single.py
+++ b/test_single.py
@@ -1,8 +1,23 @@
+# load library
 from pyMCDS import pyMCDS
 
+# load physicell data
 mcds1 = pyMCDS('output00000001.xml', 'timeseries_set')
 mcds2 = pyMCDS('output00000008.xml', 'timeseries_set')
 
+# commands to extract basic information
 print(mcds1.get_time())
-print(mcds2.get_menv_species_list())
-print(mcds2.get_concentrations('quorum'))
+print(mcds1.get_cell_variables())
+print(mcds1.get_substrate_names())
+
+# commnds to extract pandas compatible output
+print(mcds1.get_cell_df())
+print(mcds1.get_cell_df_at(x=39, y=83, z=0))
+
+# commands to extract mesh related output
+print(mcds1.get_mesh_spacing())
+print(mcds1.get_mesh())
+print(mcds1.get_2D_mesh())
+print(mcds1.get_linear_voxels())
+print(mcds1.get_containing_voxel_ijk(x=0,y=0,z=0))
+print(mcds1.get_concentrations('quorum'))

--- a/test_timeseries.py
+++ b/test_timeseries.py
@@ -1,8 +1,19 @@
-from pyMCDS import *
-from pyMCDS_timeseries import *
+# load library
+from pyMCDS_timeseries import pyMCDS_timeseries
 
+# load physicell timeseries data
 mcds = pyMCDS_timeseries('timeseries_set')
 
-chem_list = mcds.timeseries[0].get_menv_species_list()
+# command to extract basic timeseries information
+mcds.get_times()
+
+# howto extract data form a single timepoint
+# check out test_single.py for more details
+mcd1 = mcds.timeseries[0]
+print(mcd1.get_time())
+print(mcds.timeseries[0].get_time())
+
+# plotting commands
+chem_list = mcds.timeseries[0].get_substrate_names()
 mcds.plot_menv_total(chem_list)
-mcds.plot_cell_type_counts()        
+mcds.plot_cell_type_counts()


### PR DESCRIPTION
Dear Paul, Randy, and Pat,

test_single.py and test_timeseries.py were not working. They called the get_menv_species_list function that over time was renamed. I got this test files working again.at the same time I extended this test files to all functions implemented in pyMCDS.py and pyMCDS_timeseries.py, and fixed a small bug in the pyMCDS_timeseries.plot_cell_type_counts function.

  File "/.../python-loader/pyMCDS_timeseries.py", line 86, in plot_cell_type_counts
    df = self.timeseries[time_i].get_cells_df()
  AttributeError: 'pyMCDS' object has no attribute 'get_cells_df') 

All in all, the pyMCDS and pyMCDS_timeseries class provide exactly what I was looking for. Thank you for implementation.
Best, Elmar